### PR TITLE
Fix crash 'Non-static method SQL::query() cannot be called statically'

### DIFF
--- a/src/modules/BotServ/botserv.php
+++ b/src/modules/BotServ/botserv.php
@@ -49,7 +49,8 @@ class botserv {
 		)";
 		/* @param1 String $sql_query
 		 */
-		SQL::query($query);
+		$conn = sqlnew();
+		$conn->query($query);
 	}
 
 	/* To run when the class is destroyed/when the module is unloaded */

--- a/src/modules/NickServ/nickserv.php
+++ b/src/modules/NickServ/nickserv.php
@@ -49,7 +49,8 @@ class nickserv {
 		)";
 		/* @param1 String $sql_query
 		 */
-		SQL::query($query);
+		$conn = sqlnew();
+		$conn->query($query);
 	}
 
 	/* To run when the class is destroyed/when the module is unloaded */

--- a/src/modules/OperServ/operserv.php
+++ b/src/modules/OperServ/operserv.php
@@ -49,7 +49,8 @@ class operserv {
 		)";
 		/* @param1 String $sql_query
 		 */
-		SQL::query($query);
+		$conn = sqlnew();
+		$conn->query($query);
 	}
 
 	/* To run when the class is destroyed/when the module is unloaded */


### PR DESCRIPTION
Happens every time in Github Workflows:

```
PHP Fatal error:  Uncaught Error: Non-static method SQL::query() cannot be called statically in /home/runner/work/irctest/irctest/Dlk-Services/src/modules/NickServ/nickserv.php:52
Stack trace:
#0 /home/runner/work/irctest/irctest/Dlk-Services/src/module.php(71): nickserv->__construct()
#1 /home/runner/work/irctest/irctest/Dlk-Services/src/module.php(31): Module->load_module()
#2 /home/runner/work/irctest/irctest/Dlk-Services/src/module.php(194): Module->__construct()
#3 /home/runner/work/irctest/irctest/Dlk-Services/conf/modules.conf(50): loadmodule()
#4 /home/runner/work/irctest/irctest/Dlk-Services/src/main.php(79): include('...')
#5 /home/runner/work/irctest/irctest/Dlk-Services/src/dalek(2): include('...')
#6 {main}
  thrown in /home/runner/work/irctest/irctest/Dlk-Services/src/modules/NickServ/nickserv.php on line 52
```