### PR TITLE
Make cs_autoop::is_autoop a static method

### DIFF
--- a/src/modules/ChanServ/cs_autoop.php
+++ b/src/modules/ChanServ/cs_autoop.php
@@ -149,7 +149,7 @@ class cs_autoop {
 		return false;
 	}
 
-	function is_autoop(WPUser $nick,$chan)
+	static function is_autoop(WPUser $nick,$chan)
 	{
 		$conn = sqlnew();
 		$prep = $conn->prepare("SELECT * FROM ".sqlprefix()."account_settings WHERE account = ?");


### PR DESCRIPTION
It is called as such in a few places