### PR TITLE
Remove duplicate call to mysqli_stmt::get_result

### DIFF
--- a/src/modules/NickServ/ns_version_servers.php
+++ b/src/modules/NickServ/ns_version_servers.php
@@ -120,8 +120,7 @@ class ns_version_servers {
 		$prep = $conn->prepare("SELECT * FROM dalek_server_version WHERE sid = ?");
 		$prep->bind_param("s", $sid);
 		$prep->execute();
-		$result = $prep->get_result();
-		if (!($result = $prep->get_result()))
+		if (!$prep->get_result())
 		{
 			$prep = $conn->prepare("INSERT INTO dalek_server_version (sid, version) VALUES (?, ?)");
 			$prep->bind_param("ss", $sid, $version);


### PR DESCRIPTION
It may cause this error:

```
PHP Fatal error:  Uncaught mysqli_sql_exception: Commands out of sync; you can't run this command now in /home/runner/work/irctest/irctest/Dlk-Services/src/modules/NickServ/ns_version_servers.php:124
```