### PR TITLE
Add continuous integration using irctest

### DIFF
--- a/.github/workflows/irctest.yml
+++ b/.github/workflows/irctest.yml
@@ -1,0 +1,69 @@
+name: irctest
+
+on: ['push', 'pull_request']
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php-versions: ['7.4', '8.0', '8.1']
+        unrealircd-versions:
+          - 'unreal60_dev'
+          - 'cedd23ae9cdd5985ce16e9869cbdb808479c3fc4'
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python 3.9
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.9
+
+    - name: Checkout irctest
+      uses: actions/checkout@v2
+      with:
+        path: irctest
+        ref: master
+        repository: progval/irctest
+    - name: Install irctest dependencies
+      run: |-
+        python -m pip install --upgrade pip pifpaf
+        pip install pytest pytest-xdist -r irctest/requirements.txt
+
+
+
+    - name: Checkout UnrealIRCd 6
+      uses: actions/checkout@v2
+      with:
+        path: unrealircd
+        ref: ${{ matrix.unrealircd-versions }}
+        repository: unrealircd/unrealircd
+
+    - name: Build UnrealIRCd 6
+      run: |
+        cd $GITHUB_WORKSPACE/unrealircd/
+        cp $GITHUB_WORKSPACE/irctest/data/unreal/* .
+        sudo apt install libsodium-dev libargon2-dev
+        CFLAGS="-O0" CXXFLAGS="$CFLAGS" ./Config -quick
+        make -j 4
+        make install
+        # Prevent download of geoIP database on first startup
+        sed -i 's/loadmodule "geoip_classic";//' ~/.local/unrealircd/conf/modules.default.conf
+
+
+    - name: Setup PHP
+      uses: shivammathur/setup-php@v2
+      with:
+        php-version: ${{ matrix.php-versions }}
+    - name: Install wordpress
+      run: |-
+        wget -q https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar -O irctest/wp-cli.phar
+        wget -q https://wordpress.org/latest.zip -O irctest/wordpress-latest.zip
+
+    - name: Run irctest
+      run: |-
+        export PATH=~/.local/unrealircd/bin:$PATH
+        export IRCTEST_DLK_PATH="${{ github.workspace }}"
+        export IRCTEST_WP_CLI_PATH="${{ github.workspace }}/irctest/wp-cli.phar"
+        export IRCTEST_WP_ZIP_PATH="${{ github.workspace }}/irctest/wordpress-latest.zip"
+        pifpaf run mysql -- make -C irctest/ unrealircd-dlk


### PR DESCRIPTION
On each commit/PR, this will make GitHub build UnrealIRCd, and install it along with Wordpress, wp-cli, and [irctest](https://github.com/progval/irctest).

Then, it will run irctest's test suite, which tests the IRC server answers to service-related commands as expected.
If it does not, it will report the issue on the GitHub UI next to the commit/PR.