### PR TITLE
Avoid optional parameters before required parameters

### DIFF
--- a/src/client.php
+++ b/src/client.php
@@ -31,7 +31,7 @@ class Client {
 	public $uid;
 	public $modinfo;
 	public $cmds;
-	function __construct($nick,$ident,$hostmask,$uid = NULL, $gecos ,$modinfo = NULL)
+	function __construct($nick,$ident,$hostmask,$uid, $gecos ,$modinfo = NULL)
 	{
 		global $servertime;
 		$this->nick = $nick;

--- a/src/filter.php
+++ b/src/filter.php
@@ -52,7 +52,7 @@ class Filter
 	/* 
 	 * Filters a given string
 	 */
-	static function String($nick,&$mtags = NULL,&$haystack) : void
+	static function String($nick,&$mtags,&$haystack) : void
 	{
 		foreach(self::$filter_list as $filter)
 		{

--- a/src/modules/BotServ/bs_bot.php
+++ b/src/modules/BotServ/bs_bot.php
@@ -299,9 +299,9 @@ class Bot extends Client
 {
 	public static $botlist = [];
 	
-	function __construct($nick,$ident,$hostmask,$uid = NULL, $gecos ,$modinfo = NULL)
+	function __construct($nick,$ident,$hostmask,$uid, $gecos ,$modinfo = NULL)
 	{
-		Client::__construct($nick,$ident,$hostmask,$uid = NULL, $gecos ,$modinfo = NULL);
+		Client::__construct($nick,$ident,$hostmask,$uid, $gecos ,$modinfo = NULL);
 		$this->IsBotServBot = true;
 		self::add_to_bot_list($this);
 	}

--- a/src/modules/OperServ/os_jupe.php
+++ b/src/modules/OperServ/os_jupe.php
@@ -109,7 +109,7 @@ class JupeServer {
 				return $u;
 	}
 
-	function __construct($sid = "2B2", $name, $description)
+	function __construct($sid, $name, $description)
 	{
 		$this->sid = $sid;
 		$this->name = $name;

--- a/src/modules/metadata.php
+++ b/src/modules/metadata.php
@@ -83,7 +83,7 @@ class metadata {
 		hook::run(HOOKTYPE_METADATA, $array);
 	}
 	/* Send USERMETA command */
-	public static function send_usermeta($from = NULL, $to, $key, $value)
+	public static function send_usermeta($from, $to, $key, $value)
 	{
 		if (!$from)
 			$from = Conf::$settings['info']['SID'];

--- a/src/modules/sreply.php
+++ b/src/modules/sreply.php
@@ -88,7 +88,7 @@ class sreply {
 	 * @param String $context Optional parameters that give humans extra context as to where and why the reply was spawned (for example, a particular subcommand or sub-process).
 	 * @param String $message A required plain-text message which is shown to users.
 	 */
-	public static function send_fail(User $client, String $command, String $code, String $context = "", String $message)
+	public static function send_fail(User $client, String $command, String $code, String $context, String $message)
 	{
 		self::send($client, SRPL_FAIL, $code, $command, $context, $message);
 	}
@@ -100,7 +100,7 @@ class sreply {
 	 * @param String $context Optional parameters that give humans extra context as to where and why the reply was spawned (for example, a particular subcommand or sub-process).
 	 * @param String $message A required plain-text message which is shown to users.
 	 */
-	public static function send_warn(User $client, String $command, String $code, String $context = "", String $message)
+	public static function send_warn(User $client, String $command, String $code, String $context, String $message)
 	{
 		self::send($client, SRPL_WARN, $code, $command, $context, $message);
 	}
@@ -112,7 +112,7 @@ class sreply {
 	 * @param String $context Optional parameters that give humans extra context as to where and why the reply was spawned (for example, a particular subcommand or sub-process).
 	 * @param String $message A required plain-text message which is shown to users.
 	 */
-	public static function send_note(User $client, String $command, String $code, String $context = "", String $message)
+	public static function send_note(User $client, String $command, String $code, String $context, String $message)
 	{
 		self::send($client, SRPL_NOTE, $code, $command, $context, $message);
 	}

--- a/src/modules/tkl.php
+++ b/src/modules/tkl.php
@@ -184,7 +184,7 @@ function get_tkl($type,$mask,$ut = "*")
 /* wrapper for other *-line commands */
 define('TKL_ADD','+');
 define('TKL_DEL','-');
-function _line($op,$type,$user = "*",$host,$from,$expiry = 0,$reason = "No reason")
+function _line($op,$type,$user,$host,$from,$expiry = 0,$reason = "No reason")
 {
 	if (!$op || !$type || !$host) /* Minimum requirements */
 		return false;
@@ -372,7 +372,7 @@ function gline_add($host,$from = NULL,$reason = NULL,$expiry = 0,$ut = NULL)
 	if (!$from)
 		$from = Conf::$settings['info']['SID'];
 
-	if (_line(TKL_GLOBAL,TKL_ADD,$ut,$from,$expiry,$reason))
+	if (_line(TKL_GLOBAL,TKL_ADD,"*",$ut,$from,$expiry,$reason))
 		return true;
 	return false;
 }
@@ -385,7 +385,7 @@ function gline_del($host,$ut = NULL)
 	if (!$from)
 		$from = Conf::$settings['info']['SID'];
 
-	if (_line(TKL_GLOBAL,TKL_DEL,$ut,$from,$expiry,$reason))
+	if (_line(TKL_GLOBAL,TKL_DEL,"*",$ut,$from,$expiry,$reason))
 		return true;
 	return false;
 	
@@ -400,7 +400,7 @@ function gzline_add($host,$from = NULL,$reason = NULL,$expiry = 0,$ut = NULL)
 	if (!$from)
 		$from = Conf::$settings['info']['SID'];
 
-	if (_line(TKL_GZAP,TKL_ADD,$ut,$from,$expiry,$reason))
+	if (_line(TKL_GZAP,TKL_ADD,"*",$ut,$from,$expiry,$reason))
 		return true;
 	return false;
 	
@@ -414,7 +414,7 @@ function gzline_del($host,$ut = NULL)
 	if (!$from)
 		$from = Conf::$settings['info']['SID'];
 
-	if (_line(TKL_ZAP,TKL_DEL,$ut,$from,$expiry,$reason))
+	if (_line(TKL_ZAP,TKL_DEL,"*",$ut,$from,$expiry,$reason))
 		return true;
 	return false;
 	

--- a/src/rpc.php
+++ b/src/rpc.php
@@ -496,7 +496,7 @@ class RPC {
 }
 
 
-function RPCHandlerAdd($modinfo = NULL, $handler, $function, &$error)
+function RPCHandlerAdd($modinfo, $handler, $function, &$error)
 {
 	if (RPC::IsHandler($handler))
 	{


### PR DESCRIPTION
They make PHP 8.2 emit this warning: "Optional parameter $context declared before required parameter $message is implicitly treated as a required parameter"