### PR TITLE
Avoid passing NULL to string functions

### DIFF
--- a/src/cmd.php
+++ b/src/cmd.php
@@ -61,7 +61,7 @@ hook::func(HOOKTYPE_RAW, function($u)
 	$mtags = NULL;
 	
 	
-	if (strlen($u['mtags']))
+	if (strlen($u['mtags'] ?? ""))
 			$mtags = mtag_to_array($u['mtags']);
 		
 	/* one of those commands without a 'sender', spoof it as our uplink */
@@ -89,7 +89,7 @@ hook::func(HOOKTYPE_RAW, function($u)
 		'nick' => $user,
 		'dest' => $dest,
 		'cmd' => $str,
-		'params' => ltrim($params," :"),
+		'params' => $params ? ltrim($params," :") : NULL,
 		'parc' => cmd::$commands[$str]['parc']));
 });
 

--- a/src/modules/sasl.php
+++ b/src/modules/sasl.php
@@ -291,7 +291,9 @@ class IRC_SASL {
 		
 	 function check_pass($passwd)
 	{
-
+		if (!$passwd) {
+			return false;
+		}
 		if (ctype_xdigit($passwd))
 		{
 			if ($this->check_fingerprint($passwd))


### PR DESCRIPTION
PHP 8.2 complains when this happens